### PR TITLE
COMP: explicitly handle all enum cases in switch

### DIFF
--- a/libarchive/archive_read_support_format_warc.c
+++ b/libarchive/archive_read_support_format_warc.c
@@ -337,6 +337,14 @@ start_over:
 			mtime = rtime;
 		}
 		break;
+	case WT_NONE:
+	case WT_INFO:
+	case WT_META:
+	case WT_REQ:
+	case WT_RVIS:
+	case WT_CONV:
+	case WT_CONT:
+	case LAST_WT:
 	default:
 		fnam.len = 0U;
 		fnam.str = NULL;
@@ -361,6 +369,14 @@ start_over:
 			break;
 		}
 		/* FALLTHROUGH */
+	case WT_NONE:
+	case WT_INFO:
+	case WT_META:
+	case WT_REQ:
+	case WT_RVIS:
+	case WT_CONV:
+	case WT_CONT:
+	case LAST_WT:
 	default:
 		/* consume the content and start over */
 		_warc_skip(a);

--- a/libarchive/archive_write_set_format_zip.c
+++ b/libarchive/archive_write_set_format_zip.c
@@ -583,6 +583,7 @@ archive_write_zip_header(struct archive_write *a, struct archive_entry *entry)
 			zip->entry_flags |= ZIP_ENTRY_FLAG_ENCRYPTED;
 			zip->entry_encryption = zip->encryption_type;
 			break;
+		case ENCRYPTION_NONE:
 		default:
 			break;
 		}
@@ -709,6 +710,7 @@ archive_write_zip_header(struct archive_write *a, struct archive_entry *entry)
 				    + AUTH_CODE_SIZE;
 				version_needed = 20;
 				break;
+			case ENCRYPTION_NONE:
 			default:
 				break;
 			}
@@ -761,6 +763,7 @@ archive_write_zip_header(struct archive_write *a, struct archive_entry *entry)
 				if (version_needed < 20)
 					version_needed = 20;
 				break;
+			case ENCRYPTION_NONE:
 			default:
 				break;
 			}
@@ -1028,6 +1031,7 @@ archive_write_zip_data(struct archive_write *a, const void *buff, size_t s)
 				zip->cctx_valid = zip->hctx_valid = 1;
 			}
 			break;
+		case ENCRYPTION_NONE:
 		default:
 			break;
 		}
@@ -1116,6 +1120,7 @@ archive_write_zip_data(struct archive_write *a, const void *buff, size_t s)
 		break;
 #endif
 
+	case COMPRESSION_UNSPECIFIED:
 	default:
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
 		    "Invalid ZIP compression type");


### PR DESCRIPTION
In VisualStudio 2019 error C4061 happens if you don't
have a case statement for every value of an enum.
The default condition is not enough.

This fix avoids error like this:

25>C:\sq5\LibArchive\libarchive\archive_read_support_format_warc.c(344,2): error C4061: enumerator 'WT_NONE' in switch of enum 'warc_type_t' is not explicitly handled by a case label [C:\sq5\LibArchive-build\libarchive\archive.vcxproj]